### PR TITLE
feat: adds calcite and maps sdk js widget sample

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,11 @@
       <calcite-chip slot="footer-start" icon="map"></calcite-chip>
       <calcite-chip slot="footer-end" icon="home"></calcite-chip>
     </calcite-card>
+    <calcite-card>
+      <calcite-link slot="title" href="map-calcite-widgets.html">M4: application with Calcite Components and JS widgets</calcite-link>
+      <span slot="subtitle">Construct a UI with Calcite and the map.</span>
+      <calcite-chip slot="footer-start" icon="map"></calcite-chip>
+    </calcite-card>
   </calcite-card-group>
 
   <h2>Widgets and components testing</h2>

--- a/docs/map-calcite-widgets.html
+++ b/docs/map-calcite-widgets.html
@@ -36,11 +36,6 @@
       --calcite-label-margin-bottom: 0px;
     }
 
-    #header-title {
-      margin-left: 1rem;
-      margin-right: 1rem;
-    }
-
     #info-content {
       padding: 0.75rem;
     }
@@ -49,28 +44,12 @@
       margin-top: 0.25rem;
     }
 
-    #header {
-      display: flex;
-      padding: 0 1rem;
-      background-color: var(--calcite-color-foreground-1);
-    }
-
-    #header-controls {
-      display: flex;
-      margin-inline-start: auto;
-      align-self: center;
-    }
-
     .label-wrapper {
       display: flex;
       margin-inline: 1rem;
       padding: 0.5rem;
       border: 1px solid var(--calcite-color-border-1);
       cursor: pointer;
-    }
-
-    calcite-switch {
-      margin: 0 0.5rem;
     }
 
     .sr-only {
@@ -90,16 +69,9 @@
     <calcite-loader></calcite-loader>
     <calcite-shell content-behind hidden>
 
-      <!--  Header slot  -->
-      <div slot="header" id="header">
-
-        <!-- Title -->
-        <h2 id="header-title">
-          <!-- Dynamically populated -->
-        </h2>
-
-        <!-- Controls -->
-        <div id="header-controls">
+      <calcite-navigation slot="header">
+        <calcite-navigation-logo id="header-title" slot="logo"></calcite-navigation-logo>
+        <div slot="content-end">
           <!-- Dark Mode Switch -->
           <calcite-label layout="inline" class="label-wrapper">
             Dark mode: Off
@@ -107,7 +79,7 @@
             On
           </calcite-label>
         </div>
-      </div>
+      </calcite-navigation>
 
       <calcite-shell-panel slot="panel-start" display-mode="float">
         <calcite-action-bar slot="action-bar">
@@ -232,7 +204,7 @@
 
       map.when(() => {
         const { title, description, thumbnailUrl, avgRating } = map.portalItem;
-        document.querySelector("#header-title").textContent = title;
+        document.querySelector("#header-title").heading = title;
         document.querySelector("#item-description").innerHTML = description;
         document.querySelector("#item-thumbnail").src = thumbnailUrl;
         document.querySelector("#item-rating").value = avgRating;

--- a/docs/map-calcite-widgets.html
+++ b/docs/map-calcite-widgets.html
@@ -4,8 +4,8 @@
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
     <title>Educational Attainment and Household Size</title>
 
-    <script src="https://js.arcgis.com/calcite-components/2.8.1/calcite.esm.js" type="module"></script>
-    <link rel="stylesheet" href="https://js.arcgis.com/calcite-components/2.8.1/calcite.css" />
+    <script src="https://js.arcgis.com/calcite-components/2.8.2/calcite.esm.js" type="module"></script>
+    <link rel="stylesheet" href="https://js.arcgis.com/calcite-components/2.8.2/calcite.css" />
     <script src="https://js.arcgis.com/4.30/"></script>
 
     <link disabled id="arcgis-maps-sdk-theme-dark" rel="stylesheet" href="https://js.arcgis.com/4.30/esri/themes/dark/main.css" />

--- a/docs/map-calcite-widgets.html
+++ b/docs/map-calcite-widgets.html
@@ -1,0 +1,278 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
+    <title>Educational Attainment and Household Size</title>
+
+    <script src="https://js.arcgis.com/calcite-components/2.8.1/calcite.esm.js" type="module"></script>
+    <link rel="stylesheet" href="https://js.arcgis.com/calcite-components/2.8.1/calcite.css" />
+    <script src="https://js.arcgis.com/4.30/"></script>
+
+    <link disabled id="arcgis-maps-sdk-theme-dark" rel="stylesheet" href="https://js.arcgis.com/4.30/esri/themes/dark/main.css" />
+
+    <link id="arcgis-maps-sdk-theme-light" rel="stylesheet" href="https://js.arcgis.com/4.30/esri/themes/light/main.css" />
+
+  </head>
+  <style>
+    html,
+    body,
+    #viewDiv {
+      padding: 0;
+      margin: 0;
+      height: 100%;
+      width: 100%;
+    }
+
+    body {
+      display: flex;
+    }
+
+    calcite-loader {
+      align-self: center;
+      justify-self: center;
+    }
+
+    calcite-label {
+      --calcite-label-margin-bottom: 0px;
+    }
+
+    #header-title {
+      margin-left: 1rem;
+      margin-right: 1rem;
+    }
+
+    #info-content {
+      padding: 0.75rem;
+    }
+
+    calcite-rating {
+      margin-top: 0.25rem;
+    }
+
+    #header {
+      display: flex;
+      padding: 0 1rem;
+      background-color: var(--calcite-color-foreground-1);
+    }
+
+    #header-controls {
+      display: flex;
+      margin-inline-start: auto;
+      align-self: center;
+    }
+
+    .label-wrapper {
+      display: flex;
+      margin-inline: 1rem;
+      padding: 0.5rem;
+      border: 1px solid var(--calcite-color-border-1);
+      cursor: pointer;
+    }
+
+    calcite-switch {
+      margin: 0 0.5rem;
+    }
+
+  </style>
+
+  <body>
+    <calcite-loader></calcite-loader>
+    <calcite-shell content-behind hidden>
+
+      <!--  Header slot  -->
+      <div slot="header" id="header">
+
+        <!-- Title -->
+        <h2 id="header-title">
+          <!-- Dynamically populated -->
+        </h2>
+
+        <!-- Controls -->
+        <div id="header-controls">
+          <!-- Dark Mode Switch -->
+          <calcite-label layout="inline" class="label-wrapper">
+            Dark mode: Off
+            <calcite-switch></calcite-switch>
+            On
+          </calcite-label>
+        </div>
+      </div>
+
+      <calcite-shell-panel slot="panel-start" display-mode="float">
+        <calcite-action-bar slot="action-bar">
+          <calcite-action data-action-id="layers" icon="layers" text="Layers"></calcite-action>
+          <calcite-action data-action-id="basemaps" icon="basemap" text="Basemaps"></calcite-action>
+          <calcite-action data-action-id="legend" icon="legend" text="Legend"></calcite-action>
+          <calcite-action data-action-id="bookmarks" icon="bookmark" text="Bookmarks"></calcite-action>
+          <calcite-action data-action-id="print" icon="print" text="Print"></calcite-action>
+          <calcite-action data-action-id="information" icon="information" text="Information"></calcite-action>
+        </calcite-action-bar>
+        <!-- Map-specific panels (each one provides a div for ArcGIS Maps SDK for JavaScript widgets) -->
+        <calcite-panel heading="Layers" height-scale="l" data-panel-id="layers" closable closed>
+          <div id="layers-container"></div>
+        </calcite-panel>
+        <calcite-panel heading="Basemaps" height-scale="l" data-panel-id="basemaps" closable closed>
+          <div id="basemaps-container"></div>
+        </calcite-panel>
+        <calcite-panel heading="Legend" height-scale="l" data-panel-id="legend" closable closed>
+          <div id="legend-container"></div>
+        </calcite-panel>
+        <calcite-panel heading="Bookmarks" height-scale="l" data-panel-id="bookmarks" closable closed>
+          <div id="bookmarks-container"></div>
+        </calcite-panel>
+        <calcite-panel heading="Print" height-scale="l" data-panel-id="print" closable closed>
+          <div id="print-container"></div>
+        </calcite-panel>
+        <!-- Info panel (populates with info from the web map) -->
+        <calcite-panel heading="Details" data-panel-id="information" closable closed>
+          <div id="info-content">
+            <img id="item-thumbnail" alt="webmap thumbnail" />
+            <div id="item-description">
+              <!-- Dynamically populated -->
+            </div>
+            <calcite-label layout="inline">
+              <b>Rating:</b>
+              <calcite-rating id="item-rating" read-only>
+                <!-- Dynamically populated -->
+              </calcite-rating>
+            </calcite-label>
+          </div>
+        </calcite-panel>
+      </calcite-shell-panel>
+      <div id="viewDiv"></div>
+    </calcite-shell>
+  </body>
+  <script>
+    require([
+      "esri/WebMap",
+      "esri/views/MapView",
+      "esri/widgets/Bookmarks",
+      "esri/widgets/BasemapGallery",
+      "esri/widgets/LayerList",
+      "esri/widgets/Legend",
+      "esri/widgets/Print"
+    ], function(WebMap, MapView, Bookmarks, BasemapGallery, LayerList, Legend, Print) {
+      const webmapId = new URLSearchParams(window.location.search).get("webmap") ?? "210c5b77056846808c7a5ce93920be81";
+
+      const map = new WebMap({
+        portalItem: {
+          id: webmapId
+        }
+      });
+
+      const view = new MapView({
+        map,
+        container: "viewDiv",
+        padding: {
+          left: 45
+        }
+      });
+
+      view.ui.move("zoom", "top-left");
+
+      const basemaps = new BasemapGallery({
+        view,
+        container: "basemaps-container"
+      });
+
+      const bookmarks = new Bookmarks({
+        view,
+        container: "bookmarks-container"
+      });
+
+      const layerList = new LayerList({
+        view,
+        selectionMode: "none",
+        dragEnabled: true,
+        container: "layers-container",
+        visibilityAppearance: "checkbox"
+      });
+
+      const legend = new Legend({
+        view,
+        container: "legend-container"
+      });
+
+      const print = new Print({
+        view,
+        container: "print-container"
+      });
+
+      map.when(() => {
+        const { title, description, thumbnailUrl, avgRating } = map.portalItem;
+        document.querySelector("#header-title").textContent = title;
+        document.querySelector("#item-description").innerHTML = description;
+        document.querySelector("#item-thumbnail").src = thumbnailUrl;
+        document.querySelector("#item-rating").value = avgRating;
+
+        let activeWidget;
+
+        const handleActionBarClick = ({ target }) => {
+          if (target.tagName !== "CALCITE-ACTION") {
+            return;
+          }
+
+          if (activeWidget) {
+            document.querySelector(`[data-action-id=${activeWidget}]`).active = false;
+            document.querySelector(`[data-panel-id=${activeWidget}]`).closed = true;
+          }
+
+          const nextWidget = target.dataset.actionId;
+          if (nextWidget !== activeWidget) {
+            document.querySelector(`[data-action-id=${nextWidget}]`).active = true;
+            document.querySelector(`[data-panel-id=${nextWidget}]`).closed = false;
+            activeWidget = nextWidget;
+            document.querySelector(`[data-panel-id=${nextWidget}]`).setFocus();
+          } else {
+            activeWidget = null;
+          }
+        };
+
+        document.querySelector("calcite-action-bar").addEventListener("click", handleActionBarClick);
+
+          // Panel interaction
+      const panelEls = document.querySelectorAll("calcite-panel");
+      for (let i = 0; i < panelEls.length; i++) {
+        panelEls[i].addEventListener("calcitePanelClose", () => {
+          document.querySelector(`[data-action-id=${activeWidget}]`).closed = true;
+          document.querySelector(`[data-action-id=${activeWidget}]`).active = false;
+          document.querySelector(`[data-action-id=${activeWidget}]`).setFocus();
+          activeWidget = null;
+        });
+      }
+
+        let actionBarExpanded = false;
+
+        document.addEventListener("calciteActionBarToggle", event => {
+          actionBarExpanded = !actionBarExpanded;
+          view.padding = {
+            left: actionBarExpanded ? 150 : 45
+          };
+        });
+
+        document.querySelector("calcite-shell").hidden = false;
+        document.querySelector("calcite-loader").hidden = true;
+
+        const updateDarkMode = () => {
+          // Calcite mode
+          document.body.classList.toggle("calcite-mode-dark");
+          // ArcGIS Maps SDK theme
+          const dark = document.querySelector("#arcgis-maps-sdk-theme-dark");
+          const light = document.querySelector("#arcgis-maps-sdk-theme-light");
+          dark.disabled = !dark.disabled;
+          light.disabled = !light.disabled;
+          // ArcGIS Maps SDK basemap
+          map.basemap = dark.disabled ? "gray-vector" : "dark-gray-vector";
+          // Toggle ArcGIS Maps SDK widgets mode
+          const widgets = document.getElementsByClassName("esri-ui");
+          for (let i = 0; i < widgets.length; i++) {
+            widgets.item(i).classList.toggle("calcite-mode-dark");
+          }
+        };
+
+        document.querySelector("calcite-switch").addEventListener("calciteSwitchChange", updateDarkMode);
+
+      });
+    });
+  </script>
+</html>

--- a/docs/map-calcite-widgets.html
+++ b/docs/map-calcite-widgets.html
@@ -73,9 +73,20 @@
       margin: 0 0.5rem;
     }
 
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0,0,0,0);
+      border: 0;
+    }
+
   </style>
 
-  <body>
+  <body aria-describedby="map-loaded">
     <calcite-loader></calcite-loader>
     <calcite-shell content-behind hidden>
 
@@ -140,6 +151,8 @@
         </calcite-panel>
       </calcite-shell-panel>
       <div id="viewDiv"></div>
+      <p id="map-loaded" aria-live="polite" class="sr-only"></p>
+      <p id="map-description" class="sr-only"></p>
     </calcite-shell>
   </body>
   <script>
@@ -165,7 +178,10 @@
         container: "viewDiv",
         padding: {
           left: 45
-        }
+        },
+        popup: {
+          goToOverride: overrideGoToOptions
+        },
       });
 
       view.ui.move("zoom", "top-left");
@@ -177,7 +193,8 @@
 
       const bookmarks = new Bookmarks({
         view,
-        container: "bookmarks-container"
+        container: "bookmarks-container",
+        goToOverride: overrideGoToOptions
       });
 
       const layerList = new LayerList({
@@ -198,12 +215,31 @@
         container: "print-container"
       });
 
+      function isReduced() {
+        return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      }
+
+      function overrideGoToOptions(view, goToParams) {
+
+      const { target, options } = goToParams;
+
+      return view.goTo(target, {
+        ...options,
+        animate: !isReduced(),
+      });
+
+      }
+
       map.when(() => {
         const { title, description, thumbnailUrl, avgRating } = map.portalItem;
         document.querySelector("#header-title").textContent = title;
         document.querySelector("#item-description").innerHTML = description;
         document.querySelector("#item-thumbnail").src = thumbnailUrl;
         document.querySelector("#item-rating").value = avgRating;
+        document.getElementById("map-loaded").innerText = `The ${title} map has loaded.`;
+        document.getElementById("map-description").innerText = "A map of Mexico's municipalities depicting educational attainment by average household size.";
+        const surfacesEls = [...document.getElementsByClassName("esri-view-surface")];
+        surfacesEls.forEach((surfaceEl) => surfaceEl.setAttribute("aria-describedby", "map-description"));
 
         let activeWidget;
 


### PR DESCRIPTION
Adds a Calcite + Maps SDK for JS widget sample, which also includes:
- Some logic for consistent focus and the ability to close the widgets using the `esc` key
- Live region for providing context the map has loaded and a map description
- Support for reduced motion WRT the `view`'s popup and `bookmarks` widget